### PR TITLE
Rozdělení částí afterDeploye

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,35 @@ Installation & usage
 $ composer require adt/deployment
 ```
 
-2. Enable the extension in your neon config:
+2. Add this code in bootstrap.php before including autoload.php
+```php
+ include __DIR__ . '/../vendor/adt/deployment/src/Deployment.php';
+ (new ADT\Deployment\Deployment())
+ 	->runBase([
+ 		'tempDir' => '/path/to/tempDir/', //required
+ 		'key' => 'afterDeploy' // optional
+ 	]
+);
+```
+
+3. Enable the extension in your neon config:
 
 ```neon
 extensions:
 	deployment: ADT\Deployment\DI\DeploymentExtension
 ```
 
-3. Update deployment configuration file `deployment.ini` like:
+4. Update deployment configuration file `deployment.ini` like:
 ```neon
 after[] = http://example.com/?afterDeploy
 ```
 
-4. Run `dg/ftp-deployment` script
+5. Run `dg/ftp-deployment` script
 ```
 $ php private/vendor/dg/ftp-deployment/Deployment/deployment.php deployment.ini
 ```
 
-5. Optionaly you can change the key in neon config:
+6. Optionaly you can change the key in neon config (the key has to be same as the one defined in bootstrap.php):
 
 ```neon
 deployment:

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ $ composer require adt/deployment
 
 2. Add this code in bootstrap.php before including autoload.php
 ```php
- include __DIR__ . '/../vendor/adt/deployment/src/Deployment.php';
- (new ADT\Deployment\Deployment())
+ include __DIR__ . '/../vendor/adt/deployment/src/AfterDeploy.php';
+ (new ADT\AfterDeploy\AfterDeploy())
  	->runBase([
  		'tempDir' => '/path/to/tempDir/', // required
- 		'wwwDir' => '/path/to/wwwDir/', // optional, if not given, tempDir/../www is used
+ 		'wwwDir' => '/path/to/wwwDir/', // optional, if not given, tempDir/../www is used, on
  		'key' => 'afterDeploy', // optional
- 		'sleep' => 1 // optional, time to wait before afterDeploy starts in seconds
+ 		'useMaintenance' => 1 // optional, default = 0
+ 		'sleep' => 1 // optional, time to wait before afterDeploy starts in seconds, if useMaintenance is 0 it's not used
  	]
 );
 ```
@@ -34,7 +35,7 @@ $ composer require adt/deployment
 
 ```neon
 extensions:
-	deployment: ADT\Deployment\DI\DeploymentExtension
+	deployment: ADT\AfterDeploy\DI\AfterDeployExtension
 ```
 
 4. Update deployment configuration file `deployment.ini` like:
@@ -50,7 +51,7 @@ $ php private/vendor/dg/ftp-deployment/Deployment/deployment.php deployment.ini
 6. Optionaly you can set the redis in neon config:
 
 ```neon
-deployment:
+afterDeploy:
 	redis:
 		client: @redis.client # \Kdyby\Redis\RedisClient
 		dbs:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ $ composer require adt/deployment
  include __DIR__ . '/../vendor/adt/deployment/src/Deployment.php';
  (new ADT\Deployment\Deployment())
  	->runBase([
- 		'tempDir' => '/path/to/tempDir/', //required
- 		'key' => 'afterDeploy' // optional
+ 		'tempDir' => '/path/to/tempDir/', // required
+ 		'wwwDir' => '/path/to/wwwDir/', // optional, if not given, tempDir/../www is used
+ 		'key' => 'afterDeploy', // optional
+ 		'sleep' => 1 // optional, time to wait before afterDeploy starts in seconds
  	]
 );
 ```

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ $ composer require adt/deployment
 
 2. Add this code in bootstrap.php before including autoload.php
 ```php
- include __DIR__ . '/../vendor/adt/deployment/src/AfterDeploy.php';
+ include __DIR__ . '/../vendor/adt/after-deploy/src/AfterDeploy.php';
  (new ADT\AfterDeploy\AfterDeploy())
  	->runBase([
  		'tempDir' => '/path/to/tempDir/', // required
+ 		'logDir' => '/path/to/logDir/', // required
  		'wwwDir' => '/path/to/wwwDir/', // optional, if not given, tempDir/../www is used, on
  		'key' => 'afterDeploy', // optional
  		'useMaintenance' => 1 // optional, default = 0

--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ after[] = http://example.com/?afterDeploy
 $ php private/vendor/dg/ftp-deployment/Deployment/deployment.php deployment.ini
 ```
 
-6. Optionaly you can change the key in neon config (the key has to be same as the one defined in bootstrap.php):
+6. Optionaly you can set the redis in neon config:
 
 ```neon
 deployment:
-	key: mySecretKey # default: afterDeploy
 	redis:
 		client: @redis.client # \Kdyby\Redis\RedisClient
 		dbs:

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name": "adt/deployment",
+	"name": "adt/after-deploy",
 	"type": "library",
 	"description": "",
-	"keywords": ["nette", "deployment", "composer", "bower"],
+	"keywords": ["nette", "deployment", "composer", "bower", "after", "deploy", "afterDeploy", "after-deploy"],
 	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],
 	"authors": [
 		{

--- a/src/AfterDeploy.php
+++ b/src/AfterDeploy.php
@@ -187,6 +187,29 @@ class AfterDeploy {
 	}
 
 	/**
+	 * Removes email-sent file from Log dir
+	 * @param array $config
+	 */
+	protected function clearEmailSent($config = []) {
+		// clear tempDir
+		if (isset($config['logDir']) && is_dir($config['logDir'])) {
+			$count = 0;
+			if (file_exists($config['logDir'] . "/email-sent")) {
+				unlink($config['logDir'] . "/email-sent");
+				$count++;
+			}
+
+			if ($count === 0) {
+				$this->log("Email-sent file in Log dir <bgRed>was not found<reset>.");
+			} else {
+				$this->log("Email-sent file in Log dir <bgGreen>cleared<reset>.");
+			}
+		} else {
+			$this->log("Log dir for removing email-sent file <cyan>is not defined<reset>.");
+		}
+	}
+
+	/**
 	 * Clear Redis
 	 */
 	protected function clearRedis($redis = []) {
@@ -291,6 +314,7 @@ class AfterDeploy {
 
 		$this->clearCache($config);
 		$this->resetAPCandOPCache();
+		$this->clearEmailSent($config);
 
 		ob_clean();
 

--- a/src/DI/AfterDeployExtension.php
+++ b/src/DI/AfterDeployExtension.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace ADT\Deployment\DI;
+namespace ADT\AfterDeploy\DI;
 
-class DeploymentExtension extends \Nette\DI\CompilerExtension
+class AfterDeployExtension extends \Nette\DI\CompilerExtension
 {
 
 	/**

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -13,6 +13,9 @@ class Deployment {
 	 */
 	const DEFAULT_KEY = 'afterDeploy';
 
+	/** @var string */
+	protected static $key = self::DEFAULT_KEY;
+
 	/** @var array */
 	protected $commands = [];
 
@@ -29,9 +32,10 @@ class Deployment {
 	/** @var bool */
 	protected $cliMode = TRUE;
 
-	public static function onStartup($config)
-	{
-		if (static::shouldStartDeploy($config)) {
+	public static function onStartup($config) {
+		$config['key'] = static::$key;
+
+		if (!static::shouldStartDeploy($config)) {
 			return;
 		}
 
@@ -203,8 +207,8 @@ class Deployment {
 	}
 
 	protected static function shouldStartDeploy($config) {
-		$key = isset($config['key']) && !empty($config['key']) ? $config['key'] : self::DEFAULT_KEY;
-		return isset($_GET[$key]);
+		static::$key = !empty($config['key']) ? $config['key'] : static::DEFAULT_KEY;
+		return isset($_GET[static::$key]);
 	}
 
 	/**


### PR DESCRIPTION
Rozdělení na část instalační (bez závislosti na nette) a extension část. Dělá se aby se composer a bower závislosti nainstalovali dříve než se spustí aplikace, aby se vyhnulo chybám loader nemůže nalézt třídu, která ještě nebyla nainstalována