### PR TITLE
Ability to reload all BackgroundQueue consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ after[] = http://example.com/?afterDeploy
 $ php private/vendor/dg/ftp-deployment/Deployment/deployment.php deployment.ini
 ```
 
-6. Optionaly you can set the redis in neon config:
+6. Optionally you can set the redis in neon config:
 
 ```neon
 afterDeploy:
@@ -58,3 +58,13 @@ afterDeploy:
 		dbs:
 			- 1 # clear db 1
 ```
+
+7. If you use [BackgroundQueue](https://github.com/AppsDevTeam/BackgroundQueue) >= [v2.1.1](https://github.com/AppsDevTeam/BackgroundQueue/releases/tag/v2.1.1), you can optionally set it in neon config:
+
+```neon
+afterDeploy:
+	backgroundQueue:
+		service: @backgroundQueue.service # \ADT\BackgroundQueue\Service
+```
+
+This will send a noop to currently running consumers, so they check if they should terminate. Telling the consumer to terminate on next check (by `-m 1` or by sending `SIGINT` signal) is not part of this component and is up to you.

--- a/src/AfterDeploy.php
+++ b/src/AfterDeploy.php
@@ -234,6 +234,16 @@ class AfterDeploy {
 	}
 
 	/**
+	 * Reload BackgroundQueue consumers
+	 */
+	protected function clearBackgroundQueue($config = []) {
+
+		$config['service']->publishSupervisorNoop();
+
+		$this->log("BackgroundQueue consumers <bgGreen>reloaded<reset>.");
+	}
+
+	/**
 	 * Detect access via console
 	 * @return boolean
 	 */
@@ -334,6 +344,10 @@ class AfterDeploy {
 
 		if (isset($config['redis'])) {
 			$this->clearRedis($config['redis']);
+		}
+
+		if (isset($config['backgroundQueue'])) {
+			$this->clearBackgroundQueue($config['backgroundQueue']);
 		}
 
 		$this->clearCache($config);


### PR DESCRIPTION
You can send SIGINT to all of the consumers and then run AfterDeploy, which will send them noop operation. If you don't use `-w` parameter, then all of the consumers are not interrupted in the middle of process, but they end after they process their current task (eventually the noop operation).